### PR TITLE
SSD1306: make "deselect" configurable

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -1671,6 +1671,10 @@
 #contrast:
 #   The contrast to set when using a uc1701/st7567 type displays.  The value
 #   may range from 0 to 63. Default is 40 for uc1701 and 60 for st7567.
+#deselect: 0
+#   The "VCOMH deselect level" to set when using a SSD1306/SH1106 type display.
+#   This is used to adjust the black level. Value may range from 0 to 63.
+#   Default is 0
 #cs_pin:
 #dc_pin:
 #spi_bus:

--- a/klippy/extras/display/uc1701.py
+++ b/klippy/extras/display/uc1701.py
@@ -232,6 +232,7 @@ class SSD1306(DisplayBase):
             io_bus = io.spi
         self.reset = ResetHelper(config.get("reset_pin", None), io_bus)
         DisplayBase.__init__(self, io, columns)
+        self.deselect = config.getint('deselect', 0, minval=0, maxval=63)
     def init(self):
         self.reset.init()
         init_cmds = [
@@ -247,7 +248,7 @@ class SSD1306(DisplayBase):
             0xDA, 0x12, # Set COM pins hardware configuration
             0x81, 0xEF, # Set contrast control
             0xD9, 0xA1, # Set pre-charge period
-            0xDB, 0x00, # Set VCOMH deselect level
+            0xDB, self.deselect, # Set VCOMH deselect level
             0x2E,       # Deactivate scroll
             0xA4,       # Output ram to display
             0xA6,       # Normal display


### PR DESCRIPTION
Adds a variable to allow adjustment of "VCOMH deselect level" on SSD1306 and SH1106 displays. This is used to fix the black (off) value of some displays exhibiting ghosting